### PR TITLE
spectr(proposal): add-issue-sync

### DIFF
--- a/spectr/changes/add-issue-sync/design.md
+++ b/spectr/changes/add-issue-sync/design.md
@@ -1,0 +1,91 @@
+## Context
+The spectr-action currently validates Spectr specs and creates GitHub annotations for issues. Users want to track change proposals as GitHub Issues for better visibility and collaboration. This requires integrating with the GitHub Issues API, managing issue lifecycle, and maintaining a mapping between local change directories and remote issues.
+
+**Stakeholders**: Repository maintainers, contributors tracking proposals, CI/CD workflows
+
+**Constraints**:
+- Must work within GitHub Actions runtime
+- Must handle rate limits gracefully
+- Must not break existing validation-only workflows
+- Must be opt-in (disabled by default)
+
+## Goals / Non-Goals
+
+**Goals**:
+- Automatically create GitHub Issues for active change proposals
+- Keep issue content in sync with `proposal.md` and `tasks.md`
+- Close issues when changes are archived
+- Provide configurable labels and title prefixes
+- Support idempotent operations (safe to run multiple times)
+
+**Non-Goals**:
+- Two-way sync (editing issues does not update files)
+- Managing issue comments or reactions
+- PR creation or linking automation
+- Support for non-GitHub platforms
+
+## Decisions
+
+### Decision: Use HTML comments for issue-to-change mapping
+Issues will contain a hidden HTML marker at the top of the body:
+```html
+<!-- spectr-change-id:change-name -->
+```
+
+**Rationale**: This approach is:
+- Invisible to users viewing the issue
+- Survives issue body edits (users can add content below)
+- Easy to search via GitHub API
+- Used by other tools (e.g., release-drafter)
+
+**Alternatives considered**:
+- Issue labels with change ID: Labels are visible and can be accidentally removed
+- Separate state file: Adds complexity, requires file commits
+- Issue title parsing: Fragile, titles can be edited
+
+### Decision: Module structure under `src/issues/`
+New code will be organized as:
+```
+src/issues/
+  index.ts        # Main sync orchestration
+  discover.ts     # Find active changes in spectr/changes/
+  format.ts       # Generate issue body from proposal content
+  sync.ts         # Create/update/close issues via GitHub API
+  types.ts        # TypeScript types for issue sync
+```
+
+**Rationale**: Follows existing pattern of modular organization (`src/download/`, `src/utils/`). Keeps issue sync logic isolated from core validation.
+
+### Decision: Read tasks.md as optional
+Issues will include tasks if `tasks.md` exists, but will not fail if it doesn't.
+
+**Rationale**: The Spectr format requires `proposal.md` but `tasks.md` is optional. Matching this behavior avoids false negatives.
+
+### Decision: Archive detection by directory presence
+A change is considered archived when its directory exists under `spectr/changes/archive/`.
+
+**Rationale**: This matches how `spectr archive` works. No need to track state separately.
+
+## Risks / Trade-offs
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| API rate limits | Sync fails for repos with many changes | Use authenticated requests (github-token), batch operations |
+| Orphaned issues | Issues exist without matching change | Document manual cleanup process |
+| Permission errors | Workflow lacks `issues: write` | Clear error messages, documentation |
+| Marker tampering | Users remove hidden marker | Document that marker is required, create new issue if missing |
+
+## Migration Plan
+
+1. **No migration needed** - This is a new opt-in feature
+2. Users enable by adding `sync-issues: 'true'` to workflow
+3. First run creates issues for all existing active changes
+4. Subsequent runs update/close as needed
+
+**Rollback**: Remove `sync-issues: 'true'` from workflow. Existing issues remain but stop syncing.
+
+## Open Questions
+
+1. **Should we support custom issue templates?** - Deferred to future enhancement
+2. **Should we add issue assignee support?** - Deferred to future enhancement
+3. **How to handle very large proposal.md files?** - GitHub issues have a 65536 character limit; truncate with notice if exceeded

--- a/spectr/changes/add-issue-sync/proposal.md
+++ b/spectr/changes/add-issue-sync/proposal.md
@@ -1,0 +1,23 @@
+# Change: Add GitHub Issues sync for change proposals
+
+## Why
+Change proposals in `spectr/changes/` are currently only visible to developers who browse the repository's file tree. Syncing proposals to GitHub Issues provides better visibility, enables discussion via issue comments, integrates with GitHub's existing PR linking (`Fixes #N`), and automates lifecycle management when changes are archived.
+
+## What Changes
+- Add new action inputs to control issue sync behavior (`sync-issues`, `issue-labels`, `issue-title-prefix`, `close-on-archive`, `update-existing`, `spectr-label`)
+- Add new action outputs for sync results (`issues-created`, `issues-updated`, `issues-closed`, `total-changes`)
+- Implement issue discovery: scan `spectr/changes/` for active proposals with `proposal.md`
+- Implement issue creation: generate issue body from `proposal.md`, affected specs, and `tasks.md`
+- Implement issue tracking: use hidden HTML marker `<!-- spectr-change-id:ID -->` to link issues to changes
+- Implement issue updates: sync content changes when `proposal.md` or `tasks.md` is modified
+- Implement issue closure: close issues when changes are archived to `spectr/changes/archive/`
+- Requires `issues: write` permission in workflows using this feature
+
+## Impact
+- Affected specs: `issue-sync` (new capability)
+- Affected code:
+  - `action.yml` - new inputs and outputs
+  - `src/spectr-action.ts` - orchestrate issue sync
+  - `src/issues/` - new module for issue sync logic
+  - `src/types/` - types for issue sync
+- Dependencies: Octokit (already a dependency)

--- a/spectr/changes/add-issue-sync/specs/issue-sync/spec.md
+++ b/spectr/changes/add-issue-sync/specs/issue-sync/spec.md
@@ -1,0 +1,140 @@
+## ADDED Requirements
+
+### Requirement: Issue Sync Configuration
+The action SHALL accept configuration inputs to control issue synchronization behavior.
+
+#### Scenario: Issue sync disabled by default
+- WHEN the action runs without `sync-issues` input
+- THEN issue synchronization SHALL NOT be performed
+- AND validation SHALL proceed normally
+
+#### Scenario: Issue sync enabled
+- WHEN the action runs with `sync-issues: 'true'`
+- THEN the action SHALL scan for change proposals and synchronize issues
+
+#### Scenario: Custom labels configuration
+- WHEN the action runs with `issue-labels: 'rfc,needs-review'`
+- THEN created issues SHALL have labels `rfc`, `needs-review`, and the spectr-label
+- AND the default labels SHALL NOT be applied
+
+#### Scenario: Custom title prefix configuration
+- WHEN the action runs with `issue-title-prefix: '[RFC]'`
+- THEN created issue titles SHALL use the prefix `[RFC]` instead of `[Spectr Change]`
+
+---
+
+### Requirement: Change Proposal Discovery
+The action SHALL discover active change proposals by scanning the `spectr/changes/` directory.
+
+#### Scenario: Active change with proposal.md
+- WHEN a directory exists at `spectr/changes/<id>/proposal.md`
+- AND the directory is NOT under `spectr/changes/archive/`
+- THEN the change SHALL be considered active
+- AND the change SHALL be included in issue synchronization
+
+#### Scenario: Directory without proposal.md
+- WHEN a directory exists at `spectr/changes/<id>/`
+- AND no `proposal.md` file exists in that directory
+- THEN the directory SHALL be skipped
+- AND no issue SHALL be created for that directory
+
+#### Scenario: Archived change excluded
+- WHEN a change directory exists at `spectr/changes/archive/<id>/`
+- THEN the change SHALL NOT be considered active
+- AND the corresponding issue SHALL be closed if it exists
+
+---
+
+### Requirement: Issue Creation
+The action SHALL create GitHub Issues for active change proposals that do not have corresponding issues.
+
+#### Scenario: New issue created for active change
+- WHEN an active change has no corresponding GitHub Issue
+- THEN a new issue SHALL be created
+- AND the issue title SHALL follow the format `<prefix> <Human Readable Name>`
+- AND the issue body SHALL contain a hidden marker `<!-- spectr-change-id:<id> -->`
+- AND the issue body SHALL include the contents of `proposal.md`
+- AND the issue SHALL be labeled with configured labels plus the spectr-label
+
+#### Scenario: Issue body includes affected specs
+- WHEN a change has spec deltas in `spectr/changes/<id>/specs/`
+- THEN the issue body SHALL list the affected specification names
+
+#### Scenario: Issue body includes tasks when present
+- WHEN a change has a `tasks.md` file
+- THEN the issue body SHALL include the tasks content
+- WHEN a change does NOT have a `tasks.md` file
+- THEN the issue SHALL be created without a tasks section
+
+---
+
+### Requirement: Issue Updates
+The action SHALL update existing GitHub Issues when change proposal content is modified.
+
+#### Scenario: Issue body updated on proposal change
+- WHEN `update-existing` is `'true'` (default)
+- AND an active change has a corresponding GitHub Issue
+- AND the `proposal.md` content has changed since the last sync
+- THEN the issue body SHALL be updated with the new content
+- AND the hidden marker SHALL be preserved
+
+#### Scenario: Issue updates disabled
+- WHEN `update-existing` is `'false'`
+- THEN existing issues SHALL NOT be modified
+- AND new issues SHALL still be created for changes without issues
+
+---
+
+### Requirement: Issue Closure
+The action SHALL close GitHub Issues when their corresponding change proposals are archived.
+
+#### Scenario: Issue closed when change archived
+- WHEN `close-on-archive` is `'true'` (default)
+- AND a change is moved to `spectr/changes/archive/`
+- AND a corresponding GitHub Issue exists
+- THEN the issue SHALL be closed
+
+#### Scenario: Issue closure disabled
+- WHEN `close-on-archive` is `'false'`
+- THEN issues for archived changes SHALL remain open
+
+---
+
+### Requirement: Issue-Change Mapping
+The action SHALL use a hidden HTML marker to map GitHub Issues to change proposals.
+
+#### Scenario: Marker identifies change
+- WHEN an issue body contains `<!-- spectr-change-id:add-feature -->`
+- THEN the issue SHALL be mapped to the change at `spectr/changes/add-feature/`
+
+#### Scenario: Missing marker treated as orphan
+- WHEN an issue has the spectr-label but no valid marker
+- THEN the issue SHALL NOT be updated or closed by the action
+- AND a warning SHALL be logged
+
+---
+
+### Requirement: Sync Result Outputs
+The action SHALL output metrics about the synchronization operation.
+
+#### Scenario: Output counts set after sync
+- WHEN issue synchronization completes
+- THEN `issues-created` output SHALL contain the count of newly created issues
+- AND `issues-updated` output SHALL contain the count of updated issues
+- AND `issues-closed` output SHALL contain the count of closed issues
+- AND `total-changes` output SHALL contain the count of active change proposals found
+
+---
+
+### Requirement: Label Management
+The action SHALL ensure required labels exist before creating issues.
+
+#### Scenario: Label created if missing
+- WHEN an issue is being created
+- AND a configured label does not exist in the repository
+- THEN the label SHALL be created with a default color
+
+#### Scenario: Existing labels preserved
+- WHEN an issue is being updated
+- AND the issue has additional labels not managed by the action
+- THEN those labels SHALL be preserved

--- a/spectr/changes/add-issue-sync/tasks.md
+++ b/spectr/changes/add-issue-sync/tasks.md
@@ -1,0 +1,53 @@
+## 1. Action Configuration
+- [ ] 1.1 Add `sync-issues` input to `action.yml` (default: `'false'`)
+- [ ] 1.2 Add `issue-labels` input to `action.yml` (default: `'spectr,change-proposal'`)
+- [ ] 1.3 Add `issue-title-prefix` input to `action.yml` (default: `'[Spectr Change]'`)
+- [ ] 1.4 Add `close-on-archive` input to `action.yml` (default: `'true'`)
+- [ ] 1.5 Add `update-existing` input to `action.yml` (default: `'true'`)
+- [ ] 1.6 Add `spectr-label` input to `action.yml` (default: `'spectr-managed'`)
+- [ ] 1.7 Add output definitions: `issues-created`, `issues-updated`, `issues-closed`, `total-changes`
+
+## 2. Type Definitions
+- [ ] 2.1 Create `src/issues/types.ts` with interfaces for `IssueSyncConfig`, `ChangeProposal`, `SyncResult`
+- [ ] 2.2 Add input helper functions in `src/utils/inputs.ts` for new inputs
+
+## 3. Change Discovery
+- [ ] 3.1 Create `src/issues/discover.ts` module
+- [ ] 3.2 Implement `discoverActiveChanges()` - scan `spectr/changes/` excluding `archive/`
+- [ ] 3.3 Implement `discoverArchivedChanges()` - scan `spectr/changes/archive/`
+- [ ] 3.4 Implement `readProposalContent()` - read `proposal.md` content
+- [ ] 3.5 Implement `readTasksContent()` - read `tasks.md` content (optional)
+- [ ] 3.6 Implement `findAffectedSpecs()` - list spec directories in change's `specs/` folder
+
+## 4. Issue Formatting
+- [ ] 4.1 Create `src/issues/format.ts` module
+- [ ] 4.2 Implement `formatIssueTitle()` - generate title from change ID and prefix
+- [ ] 4.3 Implement `formatIssueBody()` - generate body with marker, proposal, specs, tasks
+- [ ] 4.4 Implement `extractChangeId()` - parse change ID from issue body marker
+- [ ] 4.5 Handle body truncation for large proposals (>65536 chars)
+
+## 5. GitHub API Integration
+- [ ] 5.1 Create `src/issues/sync.ts` module
+- [ ] 5.2 Implement `findManagedIssues()` - search issues by spectr-label
+- [ ] 5.3 Implement `createIssue()` - create new issue with labels
+- [ ] 5.4 Implement `updateIssue()` - update issue body and labels
+- [ ] 5.5 Implement `closeIssue()` - close issue for archived changes
+- [ ] 5.6 Implement `ensureLabelsExist()` - create labels if they don't exist
+
+## 6. Orchestration
+- [ ] 6.1 Create `src/issues/index.ts` module
+- [ ] 6.2 Implement `syncIssues()` main entry point
+- [ ] 6.3 Integrate issue sync into `src/spectr-action.ts` (conditional on `sync-issues` input)
+- [ ] 6.4 Set action outputs for sync results
+
+## 7. Testing
+- [ ] 7.1 Add unit tests for `discover.ts` functions
+- [ ] 7.2 Add unit tests for `format.ts` functions
+- [ ] 7.3 Add unit tests for `sync.ts` functions (mock Octokit)
+- [ ] 7.4 Add integration test with fixture containing `spectr/changes/`
+- [ ] 7.5 Add test for archive detection and issue closure
+
+## 8. Documentation
+- [ ] 8.1 Update README.md with issue sync feature documentation
+- [ ] 8.2 Add example workflow showing issue sync configuration
+- [ ] 8.3 Document required permissions (`issues: write`)


### PR DESCRIPTION
## Summary

Proposal for review: `add-issue-sync`

**Location**: `spectr/changes/add-issue-sync/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation and implementation plan for GitHub Issues synchronization feature, enabling automatic creation, updating, and closure of issues linked to change proposals with configurable labels and optional workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->