### PR TITLE
feat: add PR spec impact viewing feature

### DIFF
--- a/__tests__/unit/pr-impact/detect.test.ts
+++ b/__tests__/unit/pr-impact/detect.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { parseSpectrBranch } from "../../../src/pr-impact/detect";
+
+describe("parseSpectrBranch", () => {
+  it("parses proposal branch correctly", () => {
+    const result = parseSpectrBranch("spectr/proposal/add-feature");
+
+    assert.strictEqual(result.isSpectrBranch, true);
+    assert.strictEqual(result.mode, "proposal");
+    assert.strictEqual(result.changeId, "add-feature");
+  });
+
+  it("parses archive branch correctly", () => {
+    const result = parseSpectrBranch("spectr/archive/update-auth");
+
+    assert.strictEqual(result.isSpectrBranch, true);
+    assert.strictEqual(result.mode, "archive");
+    assert.strictEqual(result.changeId, "update-auth");
+  });
+
+  it("parses remove branch correctly", () => {
+    const result = parseSpectrBranch("spectr/remove/old-feature");
+
+    assert.strictEqual(result.isSpectrBranch, true);
+    assert.strictEqual(result.mode, "remove");
+    assert.strictEqual(result.changeId, "old-feature");
+  });
+
+  it("handles change IDs with hyphens", () => {
+    const result = parseSpectrBranch("spectr/proposal/add-user-auth-v2");
+
+    assert.strictEqual(result.isSpectrBranch, true);
+    assert.strictEqual(result.changeId, "add-user-auth-v2");
+  });
+
+  it("returns false for non-spectr branches", () => {
+    const result = parseSpectrBranch("feature/add-something");
+
+    assert.strictEqual(result.isSpectrBranch, false);
+    assert.strictEqual(result.mode, null);
+    assert.strictEqual(result.changeId, null);
+  });
+
+  it("returns false for main branch", () => {
+    const result = parseSpectrBranch("main");
+
+    assert.strictEqual(result.isSpectrBranch, false);
+    assert.strictEqual(result.mode, null);
+    assert.strictEqual(result.changeId, null);
+  });
+
+  it("returns false for spectr branch without mode", () => {
+    const result = parseSpectrBranch("spectr/something-else");
+
+    assert.strictEqual(result.isSpectrBranch, false);
+    assert.strictEqual(result.mode, null);
+    assert.strictEqual(result.changeId, null);
+  });
+
+  it("returns false for spectr branch without change ID", () => {
+    const result = parseSpectrBranch("spectr/proposal/");
+
+    // The regex will capture empty string for changeId
+    // Depending on behavior, this should be treated as invalid
+    assert.strictEqual(result.isSpectrBranch, false);
+  });
+});

--- a/__tests__/unit/pr-impact/format.test.ts
+++ b/__tests__/unit/pr-impact/format.test.ts
@@ -1,0 +1,258 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+  commentsMatch,
+  formatDiffPreview,
+  formatPRComment,
+  formatSummaryTable,
+} from "../../../src/pr-impact/format";
+import type { SpecChange, SpecImpact } from "../../../src/pr-impact/types";
+
+describe("formatSummaryTable", () => {
+  it("formats counts as markdown table", () => {
+    const counts = {
+      added: 3,
+      modified: 1,
+      removed: 2,
+      renamed: 0,
+      total: 6,
+    };
+
+    const table = formatSummaryTable(counts);
+
+    assert.ok(table.includes("| Operation | Count |"));
+    assert.ok(table.includes("| Added | 3 |"));
+    assert.ok(table.includes("| Modified | 1 |"));
+    assert.ok(table.includes("| Removed | 2 |"));
+    assert.ok(table.includes("| Renamed | 0 |"));
+  });
+
+  it("handles zero counts", () => {
+    const counts = {
+      added: 0,
+      modified: 0,
+      removed: 0,
+      renamed: 0,
+      total: 0,
+    };
+
+    const table = formatSummaryTable(counts);
+
+    assert.ok(table.includes("| Added | 0 |"));
+    assert.ok(table.includes("| Modified | 0 |"));
+  });
+});
+
+describe("formatDiffPreview", () => {
+  it("returns message when no changes", () => {
+    const changes: SpecChange[] = [];
+
+    const preview = formatDiffPreview(changes);
+
+    assert.strictEqual(preview, "_No spec changes detected_");
+  });
+
+  it("formats added changes", () => {
+    const changes: SpecChange[] = [
+      {
+        capabilityName: "auth",
+        content: "Users MUST authenticate before accessing.",
+        operation: "add",
+        requirementName: "User Authentication",
+      },
+    ];
+
+    const preview = formatDiffPreview(changes);
+
+    assert.ok(preview.includes("<details>"));
+    assert.ok(preview.includes("auth"));
+    assert.ok(preview.includes("#### Added"));
+    assert.ok(preview.includes("User Authentication"));
+    assert.ok(preview.includes("Users MUST authenticate"));
+  });
+
+  it("formats modified changes", () => {
+    const changes: SpecChange[] = [
+      {
+        capabilityName: "api",
+        content: "Rate limit MUST be 100 requests per minute.",
+        operation: "modify",
+        requirementName: "Rate Limiting",
+      },
+    ];
+
+    const preview = formatDiffPreview(changes);
+
+    assert.ok(preview.includes("#### Modified"));
+    assert.ok(preview.includes("Rate Limiting"));
+  });
+
+  it("formats renamed changes", () => {
+    const changes: SpecChange[] = [
+      {
+        capabilityName: "auth",
+        oldName: "Login",
+        operation: "rename",
+        requirementName: "User Authentication",
+      },
+    ];
+
+    const preview = formatDiffPreview(changes);
+
+    assert.ok(preview.includes("#### Renamed"));
+    assert.ok(preview.includes("Login"));
+    assert.ok(preview.includes("User Authentication"));
+    assert.ok(preview.includes("→"));
+  });
+
+  it("formats removed changes", () => {
+    const changes: SpecChange[] = [
+      {
+        capabilityName: "legacy",
+        operation: "remove",
+        requirementName: "Old Feature",
+      },
+    ];
+
+    const preview = formatDiffPreview(changes);
+
+    assert.ok(preview.includes("#### Removed"));
+    assert.ok(preview.includes("Old Feature"));
+  });
+
+  it("groups changes by capability", () => {
+    const changes: SpecChange[] = [
+      {
+        capabilityName: "auth",
+        content: "Content 1",
+        operation: "add",
+        requirementName: "Req 1",
+      },
+      {
+        capabilityName: "api",
+        content: "Content 2",
+        operation: "add",
+        requirementName: "Req 2",
+      },
+      {
+        capabilityName: "auth",
+        content: "Content 3",
+        operation: "modify",
+        requirementName: "Req 3",
+      },
+    ];
+
+    const preview = formatDiffPreview(changes);
+
+    // Should have two collapsible sections
+    assert.ok(preview.includes("<summary><strong>auth</strong>"));
+    assert.ok(preview.includes("<summary><strong>api</strong>"));
+  });
+});
+
+describe("formatPRComment", () => {
+  it("includes marker", () => {
+    const impact: SpecImpact = {
+      capabilities: ["auth"],
+      changeId: "add-feature",
+      changes: [],
+      counts: { added: 0, modified: 0, removed: 0, renamed: 0, total: 0 },
+      isArchived: false,
+      mode: "proposal",
+    };
+
+    const comment = formatPRComment(impact);
+
+    assert.ok(comment.includes("<!-- spectr-pr-impact:add-feature -->"));
+  });
+
+  it("includes change ID in title", () => {
+    const impact: SpecImpact = {
+      capabilities: [],
+      changeId: "my-change",
+      changes: [],
+      counts: { added: 0, modified: 0, removed: 0, renamed: 0, total: 0 },
+      isArchived: false,
+      mode: "proposal",
+    };
+
+    const comment = formatPRComment(impact);
+
+    assert.ok(comment.includes("## Spectr Impact: `my-change`"));
+  });
+
+  it("shows archive status", () => {
+    const impact: SpecImpact = {
+      capabilities: [],
+      changeId: "test",
+      changes: [],
+      counts: { added: 0, modified: 0, removed: 0, renamed: 0, total: 0 },
+      isArchived: true,
+      mode: "archive",
+    };
+
+    const comment = formatPRComment(impact);
+
+    assert.ok(comment.includes("| Archived | Yes |"));
+  });
+
+  it("shows mode capitalized", () => {
+    const impact: SpecImpact = {
+      capabilities: [],
+      changeId: "test",
+      changes: [],
+      counts: { added: 0, modified: 0, removed: 0, renamed: 0, total: 0 },
+      isArchived: false,
+      mode: "proposal",
+    };
+
+    const comment = formatPRComment(impact);
+
+    assert.ok(comment.includes("| Mode | Proposal |"));
+  });
+
+  it("includes footer with link to proposal", () => {
+    const impact: SpecImpact = {
+      capabilities: [],
+      changeId: "my-change",
+      changes: [],
+      counts: { added: 0, modified: 0, removed: 0, renamed: 0, total: 0 },
+      isArchived: false,
+      mode: "proposal",
+    };
+
+    const comment = formatPRComment(impact);
+
+    assert.ok(comment.includes("spectr/changes/my-change/proposal.md"));
+    assert.ok(comment.includes("spectr-action"));
+  });
+});
+
+describe("commentsMatch", () => {
+  it("returns true for identical comments", () => {
+    const comment = "This is a comment";
+
+    assert.ok(commentsMatch(comment, comment));
+  });
+
+  it("ignores whitespace differences", () => {
+    const comment1 = "This is  a   comment";
+    const comment2 = "This is a comment";
+
+    assert.ok(commentsMatch(comment1, comment2));
+  });
+
+  it("ignores newline differences", () => {
+    const comment1 = "Line 1\n\n\nLine 2";
+    const comment2 = "Line 1\nLine 2";
+
+    assert.ok(commentsMatch(comment1, comment2));
+  });
+
+  it("returns false for different content", () => {
+    const comment1 = "This is comment one";
+    const comment2 = "This is comment two";
+
+    assert.ok(!commentsMatch(comment1, comment2));
+  });
+});

--- a/__tests__/unit/pr-impact/types.test.ts
+++ b/__tests__/unit/pr-impact/types.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+  extractChangeIdFromComment,
+  generatePRImpactMarker,
+  PR_IMPACT_MARKER_PATTERN,
+} from "../../../src/pr-impact/types";
+
+describe("generatePRImpactMarker", () => {
+  it("generates correct marker format", () => {
+    const marker = generatePRImpactMarker("add-feature");
+
+    assert.strictEqual(marker, "<!-- spectr-pr-impact:add-feature -->");
+  });
+
+  it("handles change IDs with hyphens", () => {
+    const marker = generatePRImpactMarker("add-user-auth-v2");
+
+    assert.strictEqual(marker, "<!-- spectr-pr-impact:add-user-auth-v2 -->");
+  });
+});
+
+describe("extractChangeIdFromComment", () => {
+  it("extracts change ID from comment with marker", () => {
+    const body = `<!-- spectr-pr-impact:add-feature -->
+
+## Spectr Impact
+
+Some content here`;
+
+    const changeId = extractChangeIdFromComment(body);
+
+    assert.strictEqual(changeId, "add-feature");
+  });
+
+  it("extracts change ID with flexible whitespace", () => {
+    const body = "<!--  spectr-pr-impact:my-change  -->\nContent";
+
+    const changeId = extractChangeIdFromComment(body);
+
+    assert.strictEqual(changeId, "my-change");
+  });
+
+  it("returns null when no marker found", () => {
+    const body = "Regular PR comment without marker";
+
+    const changeId = extractChangeIdFromComment(body);
+
+    assert.strictEqual(changeId, null);
+  });
+
+  it("returns null for empty body", () => {
+    const changeId = extractChangeIdFromComment("");
+
+    assert.strictEqual(changeId, null);
+  });
+});
+
+describe("PR_IMPACT_MARKER_PATTERN", () => {
+  it("matches standard marker format", () => {
+    const marker = "<!-- spectr-pr-impact:test-change -->";
+
+    assert.ok(PR_IMPACT_MARKER_PATTERN.test(marker));
+  });
+
+  it("captures change ID correctly", () => {
+    const marker = "<!-- spectr-pr-impact:my-awesome-change -->";
+    const match = marker.match(PR_IMPACT_MARKER_PATTERN);
+
+    assert.ok(match);
+    assert.strictEqual(match[1], "my-awesome-change");
+  });
+
+  it("handles underscores in change ID", () => {
+    const marker = "<!-- spectr-pr-impact:add_feature_v2 -->";
+    const match = marker.match(PR_IMPACT_MARKER_PATTERN);
+
+    assert.ok(match);
+    assert.strictEqual(match[1], "add_feature_v2");
+  });
+
+  it("does not match invalid markers", () => {
+    const invalidMarker = "<!-- spectr-change-id:test -->";
+
+    assert.ok(!PR_IMPACT_MARKER_PATTERN.test(invalidMarker));
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,16 @@ inputs:
     required: false
     default: "spectr-managed"
 
+  pr-impact:
+    description: "Enable PR impact comment for spectr PRs. Set to 'true' to show spec changes on PR."
+    required: false
+    default: "false"
+
+  pr-impact-update-comment:
+    description: "Update existing PR impact comment instead of creating new. Set to 'false' for new comment each run."
+    required: false
+    default: "true"
+
 outputs:
   spectr-version:
     description: "The version of Spectr that was installed and used"
@@ -63,6 +73,15 @@ outputs:
 
   total-changes:
     description: "Total number of active change proposals discovered"
+
+  pr-impact-comment-created:
+    description: "Whether a new PR impact comment was created"
+
+  pr-impact-comment-updated:
+    description: "Whether an existing PR impact comment was updated"
+
+  pr-change-id:
+    description: "The spectr change ID detected from the PR branch"
 
 runs:
   using: "node20"

--- a/spectr/changes/add-pr-view-impact/proposal.md
+++ b/spectr/changes/add-pr-view-impact/proposal.md
@@ -1,0 +1,20 @@
+# Change: Add PR Spec Impact Viewing
+
+## Why
+
+When viewing PRs created with `spectr pr p` (proposal/archive/remove), users need visibility into what spec changes the PR introduces. Currently there's no automated way to see the impact of delta specs on the overall specification.
+
+## What Changes
+
+- Add PR impact comment feature to show spec changes on PRs
+- Detect spectr PRs via branch name pattern (`spectr/proposal/*`, `spectr/archive/*`, `spectr/remove/*`)
+- Parse delta spec files to extract ADDED/MODIFIED/REMOVED/RENAMED requirements
+- Display full diff preview with requirement content in PR comment
+- Show archive status for changes
+- Create/update comments automatically on spectr PRs
+
+## Impact
+
+- Affected specs: `pr-impact` (new capability)
+- Affected code: `src/pr-impact/`, `src/spectr-action.ts`, `src/utils/inputs.ts`, `action.yml`
+- Dependencies: @octokit/core, @actions/core

--- a/spectr/changes/add-pr-view-impact/specs/pr-impact/spec.md
+++ b/spectr/changes/add-pr-view-impact/specs/pr-impact/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: PR Impact Detection
+
+The action SHALL detect spectr PRs by matching the head branch against patterns:
+- `spectr/proposal/<change-id>`
+- `spectr/archive/<change-id>`
+- `spectr/remove/<change-id>`
+
+The action SHALL extract the change ID and mode from matched branches.
+
+#### Scenario: Proposal PR detected
+- WHEN running on a PR with branch `spectr/proposal/add-feature`
+- THEN the action identifies it as a spectr PR with mode "proposal" and changeId "add-feature"
+
+#### Scenario: Non-spectr PR skipped
+- WHEN running on a PR with branch `feature/add-something`
+- THEN the action skips PR impact processing
+
+### Requirement: Delta Spec Parsing
+
+The action SHALL parse delta spec files from `spectr/changes/<changeId>/specs/` to extract:
+- ADDED requirements with full content
+- MODIFIED requirements with full content
+- REMOVED requirement names
+- RENAMED requirement pairs (from/to)
+
+#### Scenario: Parse added requirements
+- WHEN a delta spec contains `## ADDED Requirements` section
+- THEN the action extracts requirement names and content from that section
+
+#### Scenario: Parse renamed requirements
+- WHEN a delta spec contains `## RENAMED Requirements` with FROM/TO pairs
+- THEN the action extracts the rename mapping
+
+### Requirement: PR Comment Generation
+
+The action SHALL generate a markdown comment containing:
+- Hidden marker for identification (`<!-- spectr-pr-impact:<changeId> -->`)
+- Summary table with operation counts (added, modified, removed, renamed)
+- List of affected capabilities
+- Full diff preview with requirement content per capability
+- Archive status indicator
+- Link to proposal file
+
+#### Scenario: Comment includes marker
+- WHEN generating a PR comment
+- THEN the comment starts with a hidden marker containing the change ID
+
+#### Scenario: Comment shows diff preview
+- WHEN generating a PR comment with spec changes
+- THEN the comment includes collapsible sections per capability showing requirement details
+
+### Requirement: Comment Management
+
+The action SHALL find existing PR impact comments by marker pattern and update them instead of creating duplicates (when `pr-impact-update-comment` is true).
+
+#### Scenario: Update existing comment
+- WHEN `pr-impact-update-comment` is true and an existing comment with matching marker exists
+- THEN the action updates the existing comment
+
+#### Scenario: Create new comment
+- WHEN no existing comment with matching marker exists
+- THEN the action creates a new PR comment
+
+### Requirement: Configuration Inputs
+
+The action SHALL accept configuration inputs:
+- `pr-impact` (default: "false") - Enable/disable the feature
+- `pr-impact-update-comment` (default: "true") - Update existing comments vs create new
+
+#### Scenario: Feature disabled by default
+- WHEN `pr-impact` input is not set
+- THEN the PR impact feature does not run
+
+#### Scenario: Feature enabled
+- WHEN `pr-impact` input is "true"
+- THEN the PR impact feature runs on spectr PRs

--- a/spectr/changes/add-pr-view-impact/tasks.md
+++ b/spectr/changes/add-pr-view-impact/tasks.md
@@ -1,0 +1,22 @@
+## 1. Core Implementation
+
+- [x] 1.1 Create type definitions (`src/pr-impact/types.ts`)
+- [x] 1.2 Implement PR detection logic (`src/pr-impact/detect.ts`)
+- [x] 1.3 Implement delta spec parsing (`src/pr-impact/calculate.ts`)
+- [x] 1.4 Implement PR comment formatting (`src/pr-impact/format.ts`)
+- [x] 1.5 Implement GitHub API integration (`src/pr-impact/comment.ts`)
+- [x] 1.6 Create orchestration module (`src/pr-impact/index.ts`)
+
+## 2. Integration
+
+- [x] 2.1 Add input configuration function (`src/utils/inputs.ts`)
+- [x] 2.2 Update action.yml with new inputs and outputs
+- [x] 2.3 Integrate PR impact into main action flow (`src/spectr-action.ts`)
+
+## 3. Testing
+
+- [x] 3.1 Add unit tests for detect module
+- [x] 3.2 Add unit tests for types module
+- [x] 3.3 Add unit tests for format module
+- [x] 3.4 Verify all tests pass
+- [x] 3.5 Build and package action

--- a/src/pr-impact/calculate.ts
+++ b/src/pr-impact/calculate.ts
@@ -1,0 +1,554 @@
+/**
+ * Spec impact calculation module
+ *
+ * Parses delta spec files and calculates the impact of changes
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { OperationCounts, PRMode, SpecChange, SpecImpact } from "./types";
+
+/**
+ * Delta type for categorizing spec changes
+ */
+type DeltaType = "ADDED" | "MODIFIED" | "REMOVED" | "RENAMED";
+
+/**
+ * Parsed delta plan from a spec file
+ */
+interface DeltaPlan {
+  added: ParsedRequirement[];
+  modified: ParsedRequirement[];
+  removed: string[];
+  renamed: RenameOp[];
+}
+
+/**
+ * Parsed requirement from a delta spec
+ */
+interface ParsedRequirement {
+  name: string;
+  content: string;
+}
+
+/**
+ * Rename operation
+ */
+interface RenameOp {
+  from: string;
+  to: string;
+}
+
+/**
+ * Check if a change is archived
+ * @param changeId - The change ID to check
+ * @param workspacePath - Root workspace path
+ * @returns true if archived
+ */
+export function checkArchiveStatus(
+  changeId: string,
+  workspacePath: string,
+): boolean {
+  const archivePath = path.join(workspacePath, "spectr", "changes", "archive");
+
+  if (!fs.existsSync(archivePath)) {
+    return false;
+  }
+
+  try {
+    const entries = fs.readdirSync(archivePath);
+    // Archive entries have format: YYYY-MM-DD-change-id
+    for (const entry of entries) {
+      if (entry.endsWith(`-${changeId}`) || entry === changeId) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Find all spec files under a change's specs directory
+ * @param changeId - The change ID
+ * @param workspacePath - Root workspace path
+ * @returns Array of {capabilityName, filePath} objects
+ */
+function findDeltaSpecFiles(
+  changeId: string,
+  workspacePath: string,
+): Array<{ capabilityName: string; filePath: string }> {
+  const specsDir = path.join(
+    workspacePath,
+    "spectr",
+    "changes",
+    changeId,
+    "specs",
+  );
+
+  if (!fs.existsSync(specsDir)) {
+    return [];
+  }
+
+  const results: Array<{ capabilityName: string; filePath: string }> = [];
+
+  try {
+    const entries = fs.readdirSync(specsDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const specFile = path.join(specsDir, entry.name, "spec.md");
+        if (fs.existsSync(specFile)) {
+          results.push({
+            capabilityName: entry.name,
+            filePath: specFile,
+          });
+        }
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return results;
+}
+
+/**
+ * Match a requirement header and extract the name
+ * Format: ### Requirement: Name
+ */
+function matchRequirementHeader(line: string): string | null {
+  if (!line.startsWith("###")) {
+    return null;
+  }
+
+  // Skip "###" and any whitespace
+  let rest = line.slice(3).trimStart();
+
+  // Must be followed by "Requirement:"
+  if (!rest.startsWith("Requirement:")) {
+    return null;
+  }
+
+  // Skip "Requirement:" and any whitespace
+  rest = rest.slice(12).trimStart();
+
+  return rest || null;
+}
+
+/**
+ * Check if a line is an H3 header (starts with "### ")
+ */
+function isH3Header(line: string): boolean {
+  return line.startsWith("### ");
+}
+
+/**
+ * Check if a line is an H2 delta section header
+ * Returns the delta type if matched, or null otherwise
+ */
+function matchH2DeltaSection(line: string): DeltaType | null {
+  if (!line.startsWith("## ")) {
+    return null;
+  }
+
+  const rest = line.slice(3).trim();
+
+  const deltaTypes: DeltaType[] = ["ADDED", "MODIFIED", "REMOVED", "RENAMED"];
+  for (const dt of deltaTypes) {
+    if (rest === `${dt} Requirements`) {
+      return dt;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the content of a delta section in the file
+ * @param content - File content
+ * @param deltaType - Type of delta section to find
+ * @returns Section content (without header), or empty string if not found
+ */
+function findDeltaSectionContent(
+  content: string,
+  deltaType: DeltaType,
+): string {
+  const sectionHeader = `## ${deltaType} Requirements`;
+  const headerStart = content.indexOf(sectionHeader);
+
+  if (headerStart === -1) {
+    return "";
+  }
+
+  // Find end of header line
+  let headerEnd = headerStart + sectionHeader.length;
+  while (headerEnd < content.length && content[headerEnd] !== "\n") {
+    headerEnd++;
+  }
+  if (headerEnd < content.length) {
+    headerEnd++; // Include the newline
+  }
+
+  // Find the next H2 header
+  const rest = content.slice(headerEnd);
+  const lines = rest.split("\n");
+  let offset = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("## ")) {
+      return rest.slice(0, offset);
+    }
+    offset += line.length + 1; // +1 for newline
+  }
+
+  return rest;
+}
+
+/**
+ * Parse requirements from a section content
+ * @param sectionContent - Content of a delta section (ADDED or MODIFIED)
+ * @returns Array of parsed requirements
+ */
+function parseRequirementsFromSection(
+  sectionContent: string,
+): ParsedRequirement[] {
+  const requirements: ParsedRequirement[] = [];
+  let currentReq: ParsedRequirement | null = null;
+
+  const lines = sectionContent.split("\n");
+
+  for (const line of lines) {
+    const name = matchRequirementHeader(line);
+    if (name) {
+      // Save previous requirement
+      if (currentReq) {
+        requirements.push(currentReq);
+      }
+      // Start new requirement
+      currentReq = {
+        content: `${line}\n`,
+        name,
+      };
+      continue;
+    }
+
+    // Check for non-requirement H3 header (ends current requirement)
+    if (isH3Header(line) && !matchRequirementHeader(line)) {
+      if (currentReq) {
+        requirements.push(currentReq);
+        currentReq = null;
+      }
+      continue;
+    }
+
+    // Check for H2 header (ends current section)
+    if (line.startsWith("## ")) {
+      break;
+    }
+
+    // Append line to current requirement
+    if (currentReq) {
+      currentReq.content += `${line}\n`;
+    }
+  }
+
+  // Save the last requirement
+  if (currentReq) {
+    requirements.push(currentReq);
+  }
+
+  return requirements;
+}
+
+/**
+ * Parse removed requirements from section content
+ * Removed requirements are just names (from headers or list items)
+ */
+function parseRemovedSection(sectionContent: string): string[] {
+  const removed: string[] = [];
+  const lines = sectionContent.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Check for requirement header
+    const name = matchRequirementHeader(trimmed);
+    if (name) {
+      removed.push(name);
+      continue;
+    }
+
+    // Check for list item (- Name or * Name)
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+      const itemText = trimmed.slice(2).trim();
+      if (itemText) {
+        removed.push(itemText);
+      }
+    }
+  }
+
+  return removed;
+}
+
+/**
+ * Match FROM line in RENAMED section
+ * Format: - FROM: `### Requirement: Old Name`
+ */
+function matchRenamedFrom(line: string): string | null {
+  const trimmed = line.trim();
+
+  if (!trimmed.startsWith("-")) {
+    return null;
+  }
+
+  let rest = trimmed.slice(1).trim();
+  const upper = rest.toUpperCase();
+
+  if (!upper.startsWith("FROM:")) {
+    return null;
+  }
+
+  rest = rest.slice(5).trim();
+
+  // Check for backtick-wrapped content
+  if (rest.startsWith("`") && rest.endsWith("`")) {
+    const content = rest.slice(1, -1);
+    const upperContent = content.toUpperCase();
+
+    if (!upperContent.startsWith("### REQUIREMENT:")) {
+      return null;
+    }
+
+    const name = content.slice(16).trim(); // len("### Requirement:") = 16
+    return name || null;
+  }
+
+  // Try without backticks: - FROM: ### Requirement: Name
+  if (!rest.startsWith("###")) {
+    return null;
+  }
+
+  rest = rest.slice(3).trimStart();
+  const restUpper = rest.toUpperCase();
+
+  if (!restUpper.startsWith("REQUIREMENT:")) {
+    return null;
+  }
+
+  const name = rest.slice(12).trim();
+  return name || null;
+}
+
+/**
+ * Match TO line in RENAMED section
+ * Format: - TO: `### Requirement: New Name`
+ */
+function matchRenamedTo(line: string): string | null {
+  const trimmed = line.trim();
+
+  if (!trimmed.startsWith("-")) {
+    return null;
+  }
+
+  let rest = trimmed.slice(1).trim();
+  const upper = rest.toUpperCase();
+
+  if (!upper.startsWith("TO:")) {
+    return null;
+  }
+
+  rest = rest.slice(3).trim();
+
+  // Check for backtick-wrapped content
+  if (rest.startsWith("`") && rest.endsWith("`")) {
+    const content = rest.slice(1, -1);
+    const upperContent = content.toUpperCase();
+
+    if (!upperContent.startsWith("### REQUIREMENT:")) {
+      return null;
+    }
+
+    const name = content.slice(16).trim();
+    return name || null;
+  }
+
+  // Try without backticks
+  if (!rest.startsWith("###")) {
+    return null;
+  }
+
+  rest = rest.slice(3).trimStart();
+  const restUpper = rest.toUpperCase();
+
+  if (!restUpper.startsWith("REQUIREMENT:")) {
+    return null;
+  }
+
+  const name = rest.slice(12).trim();
+  return name || null;
+}
+
+/**
+ * Parse renamed requirements from section content
+ * Format: FROM/TO pairs on separate lines
+ */
+function parseRenamedSection(sectionContent: string): RenameOp[] {
+  const renamed: RenameOp[] = [];
+  let currentFrom: string | null = null;
+
+  const lines = sectionContent.split("\n");
+
+  for (const line of lines) {
+    // Check for FROM line
+    const fromName = matchRenamedFrom(line);
+    if (fromName) {
+      currentFrom = fromName;
+      continue;
+    }
+
+    // Check for TO line
+    const toName = matchRenamedTo(line);
+    if (toName && currentFrom) {
+      renamed.push({
+        from: currentFrom,
+        to: toName,
+      });
+      currentFrom = null;
+    }
+  }
+
+  return renamed;
+}
+
+/**
+ * Parse a delta spec file and extract all operations
+ * @param filePath - Path to the spec.md file
+ * @returns Parsed delta plan
+ */
+export function parseDeltaSpec(filePath: string): DeltaPlan {
+  const plan: DeltaPlan = {
+    added: [],
+    modified: [],
+    removed: [],
+    renamed: [],
+  };
+
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+
+    // Parse each section
+    const addedContent = findDeltaSectionContent(content, "ADDED");
+    if (addedContent) {
+      plan.added = parseRequirementsFromSection(addedContent);
+    }
+
+    const modifiedContent = findDeltaSectionContent(content, "MODIFIED");
+    if (modifiedContent) {
+      plan.modified = parseRequirementsFromSection(modifiedContent);
+    }
+
+    const removedContent = findDeltaSectionContent(content, "REMOVED");
+    if (removedContent) {
+      plan.removed = parseRemovedSection(removedContent);
+    }
+
+    const renamedContent = findDeltaSectionContent(content, "RENAMED");
+    if (renamedContent) {
+      plan.renamed = parseRenamedSection(renamedContent);
+    }
+  } catch {
+    // Return empty plan on error
+  }
+
+  return plan;
+}
+
+/**
+ * Calculate spec impact for a change proposal
+ * @param changeId - The change ID
+ * @param workspacePath - Root workspace path
+ * @param mode - PR mode (proposal, archive, remove)
+ * @returns Full spec impact
+ */
+export async function calculateSpecImpact(
+  changeId: string,
+  workspacePath: string,
+  mode: PRMode,
+): Promise<SpecImpact> {
+  const isArchived = checkArchiveStatus(changeId, workspacePath);
+  const specFiles = findDeltaSpecFiles(changeId, workspacePath);
+
+  const changes: SpecChange[] = [];
+  const capabilities: string[] = [];
+  const counts: OperationCounts = {
+    added: 0,
+    modified: 0,
+    removed: 0,
+    renamed: 0,
+    total: 0,
+  };
+
+  for (const { capabilityName, filePath } of specFiles) {
+    capabilities.push(capabilityName);
+    const plan = parseDeltaSpec(filePath);
+
+    // Process added requirements
+    for (const req of plan.added) {
+      changes.push({
+        capabilityName,
+        content: req.content.trim(),
+        operation: "add",
+        requirementName: req.name,
+      });
+      counts.added++;
+    }
+
+    // Process modified requirements
+    for (const req of plan.modified) {
+      changes.push({
+        capabilityName,
+        content: req.content.trim(),
+        operation: "modify",
+        requirementName: req.name,
+      });
+      counts.modified++;
+    }
+
+    // Process removed requirements
+    for (const name of plan.removed) {
+      changes.push({
+        capabilityName,
+        operation: "remove",
+        requirementName: name,
+      });
+      counts.removed++;
+    }
+
+    // Process renamed requirements
+    for (const rename of plan.renamed) {
+      changes.push({
+        capabilityName,
+        oldName: rename.from,
+        operation: "rename",
+        requirementName: rename.to,
+      });
+      counts.renamed++;
+    }
+  }
+
+  counts.total =
+    counts.added + counts.modified + counts.removed + counts.renamed;
+
+  return {
+    capabilities,
+    changeId,
+    changes,
+    counts,
+    isArchived,
+    mode,
+  };
+}

--- a/src/pr-impact/comment.ts
+++ b/src/pr-impact/comment.ts
@@ -1,0 +1,172 @@
+/**
+ * GitHub API integration for PR comments
+ *
+ * Handles creating, updating, and finding PR impact comments
+ */
+
+import { Octokit } from "@octokit/core";
+import { paginateRest } from "@octokit/plugin-paginate-rest";
+import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+import type { RepoContext } from "../issues/types";
+import { PR_IMPACT_MARKER_PATTERN } from "./types";
+
+// Create Octokit with plugins
+const ExtendedOctokit = Octokit.plugin(paginateRest, restEndpointMethods);
+export type OctokitClient = InstanceType<typeof ExtendedOctokit>;
+
+/**
+ * Existing comment info
+ */
+export interface ExistingComment {
+  id: number;
+  body: string;
+}
+
+/**
+ * Create an authenticated Octokit client
+ */
+export function createOctokitClient(token: string): OctokitClient {
+  return new ExtendedOctokit({ auth: token });
+}
+
+/**
+ * Get repository context from environment
+ */
+export function getRepoContext(): RepoContext {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY environment variable is not set");
+  }
+
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY format: ${repository}`);
+  }
+
+  return { owner, repo };
+}
+
+/**
+ * Find an existing PR impact comment by marker
+ * @param octokit - Authenticated Octokit client
+ * @param repo - Repository context
+ * @param prNumber - PR number
+ * @param changeId - Change ID to search for
+ * @returns Existing comment info or null if not found
+ */
+export async function findImpactComment(
+  octokit: OctokitClient,
+  repo: RepoContext,
+  prNumber: number,
+  changeId: string,
+): Promise<ExistingComment | null> {
+  // Get all comments on the PR
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    issue_number: prNumber,
+    owner: repo.owner,
+    per_page: 100,
+    repo: repo.repo,
+  });
+
+  // Look for our marker
+  const markerPattern = new RegExp(
+    `<!--\\s*spectr-pr-impact:${changeId}\\s*-->`,
+  );
+
+  for (const comment of comments) {
+    if (comment.body && markerPattern.test(comment.body)) {
+      return {
+        body: comment.body,
+        id: comment.id,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find any existing PR impact comment (regardless of change ID)
+ * @param octokit - Authenticated Octokit client
+ * @param repo - Repository context
+ * @param prNumber - PR number
+ * @returns Existing comment info with change ID, or null if not found
+ */
+export async function findAnyImpactComment(
+  octokit: OctokitClient,
+  repo: RepoContext,
+  prNumber: number,
+): Promise<(ExistingComment & { changeId: string }) | null> {
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
+    issue_number: prNumber,
+    owner: repo.owner,
+    per_page: 100,
+    repo: repo.repo,
+  });
+
+  for (const comment of comments) {
+    if (comment.body) {
+      const match = comment.body.match(PR_IMPACT_MARKER_PATTERN);
+      if (match) {
+        return {
+          body: comment.body,
+          changeId: match[1],
+          id: comment.id,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a new PR comment
+ * @param octokit - Authenticated Octokit client
+ * @param repo - Repository context
+ * @param prNumber - PR number
+ * @param body - Comment body
+ * @returns Created comment ID and URL
+ */
+export async function createPRComment(
+  octokit: OctokitClient,
+  repo: RepoContext,
+  prNumber: number,
+  body: string,
+): Promise<{ id: number; url: string }> {
+  const response = await octokit.rest.issues.createComment({
+    body,
+    issue_number: prNumber,
+    owner: repo.owner,
+    repo: repo.repo,
+  });
+
+  return {
+    id: response.data.id,
+    url: response.data.html_url,
+  };
+}
+
+/**
+ * Update an existing PR comment
+ * @param octokit - Authenticated Octokit client
+ * @param repo - Repository context
+ * @param commentId - Comment ID to update
+ * @param body - New comment body
+ * @returns Updated comment URL
+ */
+export async function updatePRComment(
+  octokit: OctokitClient,
+  repo: RepoContext,
+  commentId: number,
+  body: string,
+): Promise<string> {
+  const response = await octokit.rest.issues.updateComment({
+    body,
+    comment_id: commentId,
+    owner: repo.owner,
+    repo: repo.repo,
+  });
+
+  return response.data.html_url;
+}

--- a/src/pr-impact/detect.ts
+++ b/src/pr-impact/detect.ts
@@ -1,0 +1,152 @@
+/**
+ * PR detection module for spectr PR impact feature
+ *
+ * Detects if running on a spectr PR and extracts relevant context
+ */
+
+import * as fs from "node:fs";
+import type { PRContext, PRMode } from "./types";
+
+/**
+ * Spectr branch pattern
+ * Matches: spectr/proposal/<change-id>, spectr/archive/<change-id>, spectr/remove/<change-id>
+ */
+const SPECTR_BRANCH_PATTERN = /^spectr\/(proposal|archive|remove)\/(.+)$/;
+
+/**
+ * Parse a branch name to extract spectr PR information
+ * @param branchName - The branch name to parse
+ * @returns Parsed branch info
+ */
+export function parseSpectrBranch(branchName: string): {
+  isSpectrBranch: boolean;
+  mode: PRMode | null;
+  changeId: string | null;
+} {
+  const match = branchName.match(SPECTR_BRANCH_PATTERN);
+
+  if (!match) {
+    return {
+      changeId: null,
+      isSpectrBranch: false,
+      mode: null,
+    };
+  }
+
+  return {
+    changeId: match[2],
+    isSpectrBranch: true,
+    mode: match[1] as PRMode,
+  };
+}
+
+/**
+ * Get PR number from GitHub event payload
+ * @returns PR number or null if not found
+ */
+export function getPRNumberFromEvent(): number | null {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return null;
+  }
+
+  try {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, "utf-8"));
+
+    // For pull_request events, the PR number is in the payload
+    if (eventData.pull_request?.number) {
+      return eventData.pull_request.number;
+    }
+
+    // For issue_comment or other PR-related events
+    if (eventData.issue?.pull_request && eventData.issue?.number) {
+      return eventData.issue.number;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the head branch name for the current PR
+ * @returns Branch name or null if not found
+ */
+export function getHeadBranchName(): string | null {
+  // GITHUB_HEAD_REF is set for pull_request events
+  const headRef = process.env.GITHUB_HEAD_REF;
+  if (headRef) {
+    return headRef;
+  }
+
+  // For push events, we can try to parse from GITHUB_REF
+  // Format: refs/heads/<branch-name>
+  const ref = process.env.GITHUB_REF;
+  if (ref?.startsWith("refs/heads/")) {
+    return ref.replace("refs/heads/", "");
+  }
+
+  // Try to read from event payload
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath) {
+    try {
+      const eventData = JSON.parse(fs.readFileSync(eventPath, "utf-8"));
+      if (eventData.pull_request?.head?.ref) {
+        return eventData.pull_request.head.ref;
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if running on a pull request event
+ * @returns true if this is a PR event
+ */
+export function isPullRequestEvent(): boolean {
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  return (
+    eventName === "pull_request" ||
+    eventName === "pull_request_target" ||
+    eventName === "pull_request_review" ||
+    eventName === "pull_request_review_comment"
+  );
+}
+
+/**
+ * Detect PR context from GitHub Actions environment
+ * @returns Full PR context with all detected information
+ */
+export function detectPRContext(): PRContext {
+  const isPR = isPullRequestEvent();
+  const branchName = getHeadBranchName();
+  const prNumber = getPRNumberFromEvent();
+
+  // Default context for non-PR events
+  if (!isPR || !branchName) {
+    return {
+      branchName,
+      changeId: null,
+      isPR,
+      isSpectrPR: false,
+      mode: null,
+      prNumber,
+    };
+  }
+
+  // Parse the branch name to check if it's a spectr PR
+  const branchInfo = parseSpectrBranch(branchName);
+
+  return {
+    branchName,
+    changeId: branchInfo.changeId,
+    isPR,
+    isSpectrPR: branchInfo.isSpectrBranch,
+    mode: branchInfo.mode,
+    prNumber,
+  };
+}

--- a/src/pr-impact/format.ts
+++ b/src/pr-impact/format.ts
@@ -1,0 +1,230 @@
+/**
+ * PR comment formatting module
+ *
+ * Formats spec impact information as Markdown for PR comments
+ */
+
+import type { OperationCounts, SpecChange, SpecImpact } from "./types";
+import { generatePRImpactMarker, MAX_COMMENT_BODY_LENGTH } from "./types";
+
+/**
+ * Format operation counts as a summary table
+ */
+export function formatSummaryTable(counts: OperationCounts): string {
+  const lines = [
+    "| Operation | Count |",
+    "|-----------|-------|",
+    `| Added | ${counts.added} |`,
+    `| Modified | ${counts.modified} |`,
+    `| Removed | ${counts.removed} |`,
+    `| Renamed | ${counts.renamed} |`,
+  ];
+
+  return lines.join("\n");
+}
+
+/**
+ * Format the status table with mode and archive status
+ */
+function formatStatusTable(impact: SpecImpact): string {
+  const archiveStatus = impact.isArchived ? "Yes" : "No";
+  const modeDisplay =
+    impact.mode.charAt(0).toUpperCase() + impact.mode.slice(1);
+
+  const lines = [
+    "| Status | Value |",
+    "|--------|-------|",
+    `| Mode | ${modeDisplay} |`,
+    `| Archived | ${archiveStatus} |`,
+  ];
+
+  return lines.join("\n");
+}
+
+/**
+ * Format affected capabilities list
+ */
+function formatCapabilitiesList(impact: SpecImpact): string {
+  if (impact.capabilities.length === 0) {
+    return "_No capabilities affected_";
+  }
+
+  // Count changes per capability
+  const changeCounts = new Map<string, number>();
+  for (const change of impact.changes) {
+    const count = changeCounts.get(change.capabilityName) || 0;
+    changeCounts.set(change.capabilityName, count + 1);
+  }
+
+  const lines: string[] = [];
+  for (const capability of impact.capabilities) {
+    const count = changeCounts.get(capability) || 0;
+    const plural = count === 1 ? "change" : "changes";
+    lines.push(`- \`${capability}\` - ${count} ${plural}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format changes for a single capability as a collapsible section
+ */
+function formatCapabilityChanges(
+  capabilityName: string,
+  changes: SpecChange[],
+): string {
+  const capabilityChanges = changes.filter(
+    (c) => c.capabilityName === capabilityName,
+  );
+
+  if (capabilityChanges.length === 0) {
+    return "";
+  }
+
+  const plural = capabilityChanges.length === 1 ? "change" : "changes";
+  const lines: string[] = [
+    "<details>",
+    `<summary><strong>${capabilityName}</strong> (${capabilityChanges.length} ${plural})</summary>`,
+    "",
+  ];
+
+  // Group by operation type
+  const added = capabilityChanges.filter((c) => c.operation === "add");
+  const modified = capabilityChanges.filter((c) => c.operation === "modify");
+  const removed = capabilityChanges.filter((c) => c.operation === "remove");
+  const renamed = capabilityChanges.filter((c) => c.operation === "rename");
+
+  if (added.length > 0) {
+    lines.push("#### Added");
+    lines.push("");
+    for (const change of added) {
+      lines.push(`##### \`Requirement: ${change.requirementName}\``);
+      if (change.content) {
+        // Format content - skip the header line if it's included
+        const content = change.content
+          .split("\n")
+          .filter((line) => !line.startsWith("### Requirement:"))
+          .join("\n")
+          .trim();
+        if (content) {
+          lines.push(content);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (modified.length > 0) {
+    lines.push("#### Modified");
+    lines.push("");
+    for (const change of modified) {
+      lines.push(`##### \`Requirement: ${change.requirementName}\``);
+      if (change.content) {
+        const content = change.content
+          .split("\n")
+          .filter((line) => !line.startsWith("### Requirement:"))
+          .join("\n")
+          .trim();
+        if (content) {
+          lines.push(content);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (renamed.length > 0) {
+    lines.push("#### Renamed");
+    lines.push("");
+    for (const change of renamed) {
+      lines.push(`- \`${change.oldName}\` → \`${change.requirementName}\``);
+    }
+    lines.push("");
+  }
+
+  if (removed.length > 0) {
+    lines.push("#### Removed");
+    lines.push("");
+    for (const change of removed) {
+      lines.push(`- \`Requirement: ${change.requirementName}\``);
+    }
+    lines.push("");
+  }
+
+  lines.push("</details>");
+
+  return lines.join("\n");
+}
+
+/**
+ * Format the full diff preview with all changes
+ */
+export function formatDiffPreview(changes: SpecChange[]): string {
+  if (changes.length === 0) {
+    return "_No spec changes detected_";
+  }
+
+  // Get unique capabilities
+  const capabilities = [...new Set(changes.map((c) => c.capabilityName))];
+
+  const sections: string[] = [];
+  for (const capability of capabilities) {
+    const section = formatCapabilityChanges(capability, changes);
+    if (section) {
+      sections.push(section);
+    }
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Format the complete PR comment body
+ */
+export function formatPRComment(impact: SpecImpact): string {
+  const marker = generatePRImpactMarker(impact.changeId);
+
+  const sections: string[] = [
+    marker,
+    "",
+    `## Spectr Impact: \`${impact.changeId}\``,
+    "",
+    formatStatusTable(impact),
+    "",
+    "### Summary",
+    "",
+    formatSummaryTable(impact.counts),
+    "",
+    "### Affected Capabilities",
+    "",
+    formatCapabilitiesList(impact),
+    "",
+    "### Changes",
+    "",
+    formatDiffPreview(impact.changes),
+    "",
+    "---",
+    `*Generated by [spectr-action](https://github.com/connerohnesorge/spectr-action) | [View proposal](spectr/changes/${impact.changeId}/proposal.md)*`,
+  ];
+
+  let body = sections.join("\n");
+
+  // Truncate if too long
+  if (body.length > MAX_COMMENT_BODY_LENGTH) {
+    const truncationNotice =
+      "\n\n_... content truncated due to length ..._\n\n---\n*Generated by spectr-action*";
+    const maxContentLength = MAX_COMMENT_BODY_LENGTH - truncationNotice.length;
+    body = body.slice(0, maxContentLength) + truncationNotice;
+  }
+
+  return body;
+}
+
+/**
+ * Check if two comment bodies are equivalent
+ * Ignores whitespace differences
+ */
+export function commentsMatch(existing: string, updated: string): boolean {
+  const normalize = (s: string) => s.replace(/\s+/g, " ").trim();
+  return normalize(existing) === normalize(updated);
+}

--- a/src/pr-impact/index.ts
+++ b/src/pr-impact/index.ts
@@ -1,0 +1,164 @@
+/**
+ * PR Impact feature main module
+ *
+ * Orchestrates detection, calculation, formatting, and commenting
+ */
+
+import * as core from "@actions/core";
+import { calculateSpecImpact } from "./calculate";
+import {
+  createOctokitClient,
+  createPRComment,
+  findImpactComment,
+  getRepoContext,
+  updatePRComment,
+} from "./comment";
+import { detectPRContext } from "./detect";
+import { commentsMatch, formatPRComment } from "./format";
+import type { PRImpactConfig, PRImpactResult } from "./types";
+
+/**
+ * Run the PR impact feature
+ *
+ * 1. Detects if running on a spectr PR
+ * 2. Calculates spec impact from delta specs
+ * 3. Creates or updates a PR comment with the impact
+ *
+ * @param config - PR impact configuration
+ * @param workspacePath - Root workspace path
+ * @returns Result of the operation
+ */
+export async function runPRImpact(
+  config: PRImpactConfig,
+  workspacePath: string,
+): Promise<PRImpactResult> {
+  // Default result for when we don't run
+  const defaultResult: PRImpactResult = {
+    changeId: null,
+    commentCreated: false,
+    commentUpdated: false,
+    commentUrl: null,
+    mode: null,
+    ran: false,
+  };
+
+  // 1. Detect PR context
+  const prContext = detectPRContext();
+
+  if (!prContext.isPR) {
+    core.info("Not running on a pull request event");
+    return defaultResult;
+  }
+
+  if (!prContext.isSpectrPR) {
+    core.info(`Not a spectr PR branch: ${prContext.branchName || "unknown"}`);
+    return defaultResult;
+  }
+
+  if (!prContext.prNumber) {
+    core.warning("Could not determine PR number from event");
+    return defaultResult;
+  }
+
+  if (!prContext.changeId || !prContext.mode) {
+    core.warning("Could not extract change ID or mode from branch name");
+    return defaultResult;
+  }
+
+  core.info(`Detected spectr PR: ${prContext.mode}/${prContext.changeId}`);
+  core.info(`PR number: ${prContext.prNumber}`);
+
+  // 2. Calculate spec impact
+  core.info("Calculating spec impact...");
+  const impact = await calculateSpecImpact(
+    prContext.changeId,
+    workspacePath,
+    prContext.mode,
+  );
+
+  core.info(
+    `Found ${impact.counts.total} spec changes across ${impact.capabilities.length} capabilities`,
+  );
+  core.info(`  Added: ${impact.counts.added}`);
+  core.info(`  Modified: ${impact.counts.modified}`);
+  core.info(`  Removed: ${impact.counts.removed}`);
+  core.info(`  Renamed: ${impact.counts.renamed}`);
+  core.info(`  Archived: ${impact.isArchived ? "Yes" : "No"}`);
+
+  // 3. Format PR comment
+  const commentBody = formatPRComment(impact);
+
+  // 4. Create or update comment
+  const octokit = createOctokitClient(config.githubToken);
+  const repo = getRepoContext();
+
+  let commentCreated = false;
+  let commentUpdated = false;
+  let commentUrl: string | null = null;
+
+  // Check for existing comment
+  const existingComment = await findImpactComment(
+    octokit,
+    repo,
+    prContext.prNumber,
+    prContext.changeId,
+  );
+
+  if (existingComment) {
+    // Check if update is needed
+    if (config.updateComment) {
+      if (!commentsMatch(existingComment.body, commentBody)) {
+        core.info("Updating existing PR impact comment...");
+        commentUrl = await updatePRComment(
+          octokit,
+          repo,
+          existingComment.id,
+          commentBody,
+        );
+        commentUpdated = true;
+        core.info(`Updated comment: ${commentUrl}`);
+      } else {
+        core.info("Existing comment is up to date, skipping update");
+        // Get the URL from the API since we don't have it cached
+        commentUrl = `https://github.com/${repo.owner}/${repo.repo}/pull/${prContext.prNumber}#issuecomment-${existingComment.id}`;
+      }
+    } else {
+      core.info(
+        "Existing comment found but updateComment is disabled, creating new comment",
+      );
+      const result = await createPRComment(
+        octokit,
+        repo,
+        prContext.prNumber,
+        commentBody,
+      );
+      commentUrl = result.url;
+      commentCreated = true;
+      core.info(`Created comment: ${commentUrl}`);
+    }
+  } else {
+    // Create new comment
+    core.info("Creating new PR impact comment...");
+    const result = await createPRComment(
+      octokit,
+      repo,
+      prContext.prNumber,
+      commentBody,
+    );
+    commentUrl = result.url;
+    commentCreated = true;
+    core.info(`Created comment: ${commentUrl}`);
+  }
+
+  return {
+    changeId: prContext.changeId,
+    commentCreated,
+    commentUpdated,
+    commentUrl,
+    mode: prContext.mode,
+    ran: true,
+  };
+}
+
+// Re-export types for convenience
+export type { PRImpactConfig, PRImpactResult } from "./types";

--- a/src/pr-impact/types.ts
+++ b/src/pr-impact/types.ts
@@ -1,0 +1,128 @@
+/**
+ * TypeScript type definitions for PR spec impact feature
+ */
+
+/**
+ * Configuration for PR impact comment behavior
+ */
+export interface PRImpactConfig {
+  /** Enable PR impact comment feature */
+  enabled: boolean;
+  /** GitHub token for API access */
+  githubToken: string;
+  /** Update existing comment instead of creating new */
+  updateComment: boolean;
+}
+
+/**
+ * PR mode determined from branch name
+ */
+export type PRMode = "proposal" | "archive" | "remove";
+
+/**
+ * Detected PR context from GitHub Actions environment
+ */
+export interface PRContext {
+  /** Whether running on a pull request event */
+  isPR: boolean;
+  /** Whether the PR is from a spectr branch */
+  isSpectrPR: boolean;
+  /** PR number (if on a PR) */
+  prNumber: number | null;
+  /** Head branch name */
+  branchName: string | null;
+  /** Change ID extracted from branch name */
+  changeId: string | null;
+  /** PR mode (proposal, archive, remove) */
+  mode: PRMode | null;
+}
+
+/**
+ * A single spec change (add/modify/remove/rename)
+ */
+export interface SpecChange {
+  /** Capability name (directory under specs/) */
+  capabilityName: string;
+  /** Type of operation */
+  operation: "add" | "modify" | "remove" | "rename";
+  /** Requirement name */
+  requirementName: string;
+  /** Full requirement content (for add/modify) */
+  content?: string;
+  /** Original name (for renames) */
+  oldName?: string;
+}
+
+/**
+ * Full impact summary for a change
+ */
+export interface SpecImpact {
+  /** Change ID */
+  changeId: string;
+  /** PR mode */
+  mode: PRMode;
+  /** Whether the change is archived */
+  isArchived: boolean;
+  /** List of affected capability names */
+  capabilities: string[];
+  /** All spec changes */
+  changes: SpecChange[];
+  /** Operation counts */
+  counts: OperationCounts;
+}
+
+/**
+ * Operation counts for summary
+ */
+export interface OperationCounts {
+  added: number;
+  modified: number;
+  removed: number;
+  renamed: number;
+  total: number;
+}
+
+/**
+ * Result of the PR impact operation
+ */
+export interface PRImpactResult {
+  /** Whether the feature ran (false if not on spectr PR) */
+  ran: boolean;
+  /** Detected change ID */
+  changeId: string | null;
+  /** Detected PR mode */
+  mode: PRMode | null;
+  /** Whether a new comment was created */
+  commentCreated: boolean;
+  /** Whether an existing comment was updated */
+  commentUpdated: boolean;
+  /** URL to the comment (if created/updated) */
+  commentUrl: string | null;
+}
+
+/**
+ * Marker comment pattern for identifying PR impact comments
+ * Format: <!-- spectr-pr-impact:CHANGE_ID -->
+ */
+export const PR_IMPACT_MARKER_PATTERN =
+  /<!--\s*spectr-pr-impact:([a-zA-Z0-9_-]+)\s*-->/;
+
+/**
+ * Maximum comment body length (GitHub limit)
+ */
+export const MAX_COMMENT_BODY_LENGTH = 65536;
+
+/**
+ * Generate the marker comment for a change ID
+ */
+export function generatePRImpactMarker(changeId: string): string {
+  return `<!-- spectr-pr-impact:${changeId} -->`;
+}
+
+/**
+ * Extract change ID from comment body using marker pattern
+ */
+export function extractChangeIdFromComment(body: string): string | null {
+  const match = body.match(PR_IMPACT_MARKER_PATTERN);
+  return match ? match[1] : null;
+}

--- a/src/utils/inputs.ts
+++ b/src/utils/inputs.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import type { IssueSyncConfig } from "../issues/types";
+import type { PRImpactConfig } from "../pr-impact/types";
 
 export const version = core.getInput("version");
 export const githubToken = core.getInput("github-token");
@@ -38,4 +39,19 @@ function parseLabels(labelsInput: string): string[] {
     .split(",")
     .map((label) => label.trim())
     .filter((label) => label.length > 0);
+}
+
+/**
+ * Get PR impact configuration from action inputs
+ */
+export function getPRImpactConfig(): PRImpactConfig {
+  const prImpact = core.getInput("pr-impact");
+  const updateComment = core.getInput("pr-impact-update-comment");
+  const token = core.getInput("github-token");
+
+  return {
+    enabled: prImpact.toLowerCase() === "true",
+    githubToken: token,
+    updateComment: updateComment.toLowerCase() !== "false",
+  };
 }


### PR DESCRIPTION
## Summary

- Add feature to display spec impact as a PR comment when viewing PRs created with `spectr pr p`
- The comment shows operation counts, archive status, affected capabilities, and full diff preview
- Detect spectr PRs via branch name pattern matching (`spectr/proposal/*`, `spectr/archive/*`, `spectr/remove/*`)
- Parse delta spec files to extract ADDED/MODIFIED/REMOVED/RENAMED requirements

## Changes

**New module `src/pr-impact/`:**
- `types.ts` - Type definitions for PR impact feature
- `detect.ts` - PR detection using GitHub Actions env vars
- `calculate.ts` - Delta spec parsing (ported from Go CLI)
- `format.ts` - PR comment formatting with markdown tables and collapsible sections
- `comment.ts` - GitHub API integration for creating/updating comments
- `index.ts` - Main orchestration

**Modified files:**
- `action.yml` - New inputs (`pr-impact`, `pr-impact-update-comment`) and outputs
- `src/spectr-action.ts` - Integration with main action flow
- `src/utils/inputs.ts` - Configuration parsing

**Tests:**
- Unit tests for detect, types, and format modules

**Spectr proposal:**
- `spectr/changes/add-pr-view-impact/` with proposal, tasks, and spec

## Usage

```yaml
- uses: connerohnesorge/spectr-action@v1
  with:
    pr-impact: 'true'
    github-token: ${{ secrets.GITHUB_TOKEN }}
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] Biome check passes (`npm run check`)
- [x] Package generates (`npm run package`)
- [x] Unit tests pass (35 tests)
- [x] Spectr validation passes (`spectr validate add-pr-view-impact --strict`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)