### PR TITLE
Remove --strict flag (spectr is now strict by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub Action to run Spectr
 
 > GitHub Action for validating spec-driven development projects using Spectr
 
-This action automatically validates your specification-driven codebase by running `spectr validate --all --strict --json` and reporting issues as GitHub annotations.
+This action automatically validates your specification-driven codebase by running `spectr validate --all --json` and reporting issues as GitHub annotations.
 
 ## Purpose
 
@@ -21,7 +21,7 @@ This action:
 - Installs the specified version of Spectr (or latest)
 - Runs comprehensive validation on your `spectr/` directory
 - Creates GitHub annotations for any errors, warnings, or info messages
-- Fails the workflow if validation errors are found (or warnings, if strict mode is enabled)
+- Fails the workflow if validation errors or warnings are found
 - Provides detailed file locations and line numbers for issues
 
 ### When to use this action
@@ -49,7 +49,7 @@ jobs:
       - uses: connerohnesorge/spectr-action@v1
 ```
 
-That's it! The action will use the latest version of Spectr and run in strict mode by default.
+That's it! The action will use the latest version of Spectr.
 
 ## Inputs
 
@@ -64,12 +64,6 @@ That's it! The action will use the latest version of Spectr and run in strict mo
 **Description:** GitHub token used to increase rate limits when retrieving versions and downloading Spectr. Uses the default GitHub Actions token automatically.
 **Required:** No
 **Default:** `${{ github.token }}`
-
-### `strict`
-
-**Description:** Treat warnings as errors (enables `--strict` mode). Set to `false` to allow warnings without failing the build.
-**Required:** No
-**Default:** `true`
 
 ### `sync-issues`
 
@@ -143,7 +137,7 @@ That's it! The action will use the latest version of Spectr and run in strict mo
 The action automatically creates GitHub annotations for all validation issues:
 
 - **Errors** (red): Critical problems that must be fixed
-- **Warnings** (yellow): Issues that should be addressed (fail in strict mode)
+- **Warnings** (yellow): Issues that should be addressed
 - **Info** (blue): Informational messages
 
 Each annotation includes:
@@ -177,25 +171,7 @@ jobs:
       - uses: connerohnesorge/spectr-action@v1
 ```
 
-### Example 2: Strict Mode Disabled
-
-Allow warnings without failing the build:
-
-```yaml
-name: Spectr Validation
-on: [push, pull_request]
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: connerohnesorge/spectr-action@v1
-        with:
-          strict: "false"
-```
-
-### Example 3: Specific Version
+### Example 2: Specific Version
 
 Pin to a specific Spectr version for consistency:
 
@@ -242,7 +218,6 @@ jobs:
         id: spectr
         with:
           version: latest
-          strict: true
 
       - name: Print validation summary
         if: always()
@@ -270,39 +245,9 @@ jobs:
         with:
           version: "0.1.0"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          strict: "true"
 ```
 
-### Example 6: Multiple Validation Jobs
-
-Run both strict and non-strict validation in parallel:
-
-```yaml
-name: Comprehensive Validation
-on: [push, pull_request]
-
-jobs:
-  validate-strict:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Strict validation
-        uses: connerohnesorge/spectr-action@v1
-        with:
-          strict: "true"
-
-  validate-warnings-only:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Warning check (non-blocking)
-        uses: connerohnesorge/spectr-action@v1
-        with:
-          strict: "false"
-        continue-on-error: true
-```
-
-### Example 7: Using Outputs
+### Example 6: Using Outputs
 
 Capture and use the Spectr version output:
 
@@ -330,7 +275,7 @@ jobs:
         run: echo "Validation passed, ready to merge!"
 ```
 
-### Example 8: Issue Sync
+### Example 7: Issue Sync
 
 Enable automatic GitHub Issues sync for change proposals:
 
@@ -401,7 +346,6 @@ jobs:
         id: spectr-validate
         with:
           version: latest
-          strict: true
           github-token: ${{ github.token }}
 
       - name: Report validation results
@@ -511,7 +455,7 @@ Warnings:
   - Invalid spec format
   - Broken references
 
-- **Warning**: Best practice violations (fail in strict mode)
+- **Warning**: Best practice violations that should be addressed
   - Formatting recommendations
   - Potential improvements
   - Style inconsistencies
@@ -567,7 +511,7 @@ jobs:
 
 1. Update to the latest action version
 2. Check the spectr version compatibility
-3. Run `spectr validate --all --strict --json` locally to debug
+3. Run `spectr validate --all --json` locally to debug
 
 ```yaml
 - uses: connerohnesorge/spectr-action@v1 # Uses latest action
@@ -613,7 +557,7 @@ repository-root/
 
 **Solutions:**
 
-1. Run `spectr validate --all --strict` locally to see detailed output
+1. Run `spectr validate --all` locally to see detailed output
 2. Check for invisible characters or formatting issues
 3. Verify spec format follows Spectr conventions (see Spectr documentation)
 4. Ensure all requirements have at least one scenario with `#### Scenario:` format

--- a/__tests__/integration/spectr-validation.test.ts
+++ b/__tests__/integration/spectr-validation.test.ts
@@ -42,23 +42,19 @@ async function runSpectrValidation(
   let stdout = "";
   let stderr = "";
 
-  const _exitCode = await exec(
-    "spectr",
-    ["validate", "--all", "--strict", "--json"],
-    {
-      cwd: fixturePath,
-      ignoreReturnCode: true,
-      listeners: {
-        stderr: (data: Buffer) => {
-          stderr += data.toString();
-        },
-        stdout: (data: Buffer) => {
-          stdout += data.toString();
-        },
+  const _exitCode = await exec("spectr", ["validate", "--all", "--json"], {
+    cwd: fixturePath,
+    ignoreReturnCode: true,
+    listeners: {
+      stderr: (data: Buffer) => {
+        stderr += data.toString();
       },
-      silent: true,
+      stdout: (data: Buffer) => {
+        stdout += data.toString();
+      },
     },
-  );
+    silent: true,
+  });
 
   // Extract JSON from output (stderr may contain error messages after JSON)
   const jsonMatch = stdout.match(/^\[[\s\S]*\]$/m);
@@ -83,23 +79,19 @@ async function runSpectrValidationExpectingFailure(
   let stdout = "";
   let stderr = "";
 
-  const exitCode = await exec(
-    "spectr",
-    ["validate", "--all", "--strict", "--json"],
-    {
-      cwd: fixturePath,
-      ignoreReturnCode: true,
-      listeners: {
-        stderr: (data: Buffer) => {
-          stderr += data.toString();
-        },
-        stdout: (data: Buffer) => {
-          stdout += data.toString();
-        },
+  const exitCode = await exec("spectr", ["validate", "--all", "--json"], {
+    cwd: fixturePath,
+    ignoreReturnCode: true,
+    listeners: {
+      stderr: (data: Buffer) => {
+        stderr += data.toString();
       },
-      silent: true,
+      stdout: (data: Buffer) => {
+        stdout += data.toString();
+      },
     },
-  );
+    silent: true,
+  });
 
   // For failures, JSON is in stdout but error message is in stderr
   const jsonMatch = stdout.match(/^\[[\s\S]*\]$/m);

--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,6 @@ inputs:
     required: false
     default: ${{ github.token }}
 
-  strict:
-    description: "Treat warnings as errors (enables --strict mode). Set to 'false' to ignore warnings."
-    required: false
-    default: "true"
-
   sync-issues:
     description: "Enable GitHub Issues sync for change proposals. Set to 'true' to create/update issues."
     required: false

--- a/dist/spectr-action/index.js
+++ b/dist/spectr-action/index.js
@@ -29284,8 +29284,7 @@ async function run() {
         // 1. Get inputs
         const version = core.getInput("version");
         const githubToken = core.getInput("github-token");
-        const strict = core.getBooleanInput("strict");
-        core.info(`Starting spectr validation (strict: ${strict})`);
+        core.info("Starting spectr validation");
         // 2. Setup platform and architecture
         const platform = (0, platforms_1.getPlatform)();
         const arch = (0, platforms_1.getArch)();
@@ -29299,7 +29298,7 @@ async function run() {
         const spectrPath = await setupSpectr(platform, arch, version, githubToken);
         core.info(`Successfully installed spectr at ${spectrPath}`);
         // 4. Run spectr validation
-        const validationOutput = await runSpectrValidation(spectrPath, strict);
+        const validationOutput = await runSpectrValidation(spectrPath);
         // 5. Process results and create annotations
         const hasErrors = await processValidationResults(validationOutput);
         // 6. Run issue sync if enabled
@@ -29355,16 +29354,13 @@ async function setupSpectr(platform, arch, versionInput, githubToken) {
 /**
  * Run spectr validation and return parsed JSON output
  */
-async function runSpectrValidation(spectrPath, strict) {
+async function runSpectrValidation(spectrPath) {
     const workspacePath = process.env.GITHUB_WORKSPACE;
     if (!workspacePath) {
         throw new Error("GITHUB_WORKSPACE environment variable is not set");
     }
     // Build command arguments
     const args = ["validate", "--all", "--json"];
-    if (strict) {
-        args.push("--strict");
-    }
     core.info(`Running: ${spectrPath} ${args.join(" ")}`);
     core.info(`Working directory: ${workspacePath}`);
     // Capture stdout
@@ -29496,7 +29492,7 @@ run();
  * TypeScript type definitions for spectr validation output
  *
  * These types match the JSON output structure from:
- * `spectr validate --all --strict --json`
+ * `spectr validate --all --json`
  */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.formatAllIssues = exports.formatIssue = exports.getResultsWithErrors = exports.getFailedResults = exports.allValid = exports.hasAnyErrors = exports.getTotalInfoCount = exports.getTotalWarningCount = exports.getTotalErrorCount = exports.getAllInfo = exports.getAllWarnings = exports.getAllErrors = exports.getTotalIssueCount = exports.hasError = exports.hasReport = exports.isValid = void 0;

--- a/src/spectr-action.ts
+++ b/src/spectr-action.ts
@@ -21,9 +21,8 @@ async function run(): Promise<void> {
     // 1. Get inputs
     const version = core.getInput("version");
     const githubToken = core.getInput("github-token");
-    const strict = core.getBooleanInput("strict");
 
-    core.info(`Starting spectr validation (strict: ${strict})`);
+    core.info("Starting spectr validation");
 
     // 2. Setup platform and architecture
     const platform = getPlatform();
@@ -41,7 +40,7 @@ async function run(): Promise<void> {
     core.info(`Successfully installed spectr at ${spectrPath}`);
 
     // 4. Run spectr validation
-    const validationOutput = await runSpectrValidation(spectrPath, strict);
+    const validationOutput = await runSpectrValidation(spectrPath);
 
     // 5. Process results and create annotations
     const hasErrors = await processValidationResults(validationOutput);
@@ -121,7 +120,6 @@ async function setupSpectr(
  */
 async function runSpectrValidation(
   spectrPath: string,
-  strict: boolean,
 ): Promise<ValidationOutput> {
   const workspacePath = process.env.GITHUB_WORKSPACE;
   if (!workspacePath) {
@@ -130,9 +128,6 @@ async function runSpectrValidation(
 
   // Build command arguments
   const args = ["validate", "--all", "--json"];
-  if (strict) {
-    args.push("--strict");
-  }
 
   core.info(`Running: ${spectrPath} ${args.join(" ")}`);
   core.info(`Working directory: ${workspacePath}`);

--- a/src/types/spectr.ts
+++ b/src/types/spectr.ts
@@ -2,7 +2,7 @@
  * TypeScript type definitions for spectr validation output
  *
  * These types match the JSON output structure from:
- * `spectr validate --all --strict --json`
+ * `spectr validate --all --json`
  */
 
 /**
@@ -71,7 +71,7 @@ export interface BulkResult {
 
 /**
  * Array of validation results returned by bulk validation
- * Output from: `spectr validate --all --strict --json`
+ * Output from: `spectr validate --all --json`
  */
 export type ValidationOutput = BulkResult[];
 


### PR DESCRIPTION
## Summary
- Remove `strict` input parameter from action.yml since spectr no longer has a `--strict` flag
- Update command args in spectr-action.ts to not include `--strict`
- Update integration tests to not use the `--strict` flag
- Update README.md to remove all strict-related documentation and examples

## Test plan
- [x] `npm run build` passes
- [x] `npm run check` passes (only pre-existing warnings)
- [x] `npm run package` bundles dist successfully
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `strict` mode input option from the action
  * Validation failures now triggered by errors only; warnings no longer cause failures

* **Documentation**
  * Updated validation examples and guidance throughout documentation
  * Simplified command references to reflect updated validation workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->